### PR TITLE
fixed bug in normalisation: lambda-bindings not shadowing environment vars

### DIFF
--- a/index.lhs
+++ b/index.lhs
@@ -301,9 +301,8 @@ renaming (which is called 'alpha-conversion').
 norm :: [(String, Term)] -> Term -> Term
 norm env term = case eval env term of
   Var v   -> Var v
-  Lam v m -> Lam v (rec m)
-  App m n -> App (rec m) (rec n)
-  where rec = norm env
+  Lam v m -> Lam v (norm (filter (\(w,t) -> w /= v) env) m)
+  App m n -> App (norm env m) (norm env n)
 \end{code}
 
 A term with no free variables is called a 'closed lambda expression' or


### PR DESCRIPTION
There’s a small bug in the lambda-calculus interpreter in index.lhs: lambda-bindings should shadow environment let-assignments as you describe in the text, but in the implementation of normalisation, they don’t (violating e.g. α-equivalence, and generally expected behaviour).  This PR fixes that bug.

Test example (from commandline session, can be also tested on website):
```
> p1 = \p. p (\x y . x)
> \p1. p1
λp1 p.p(λx y.x)
> (\x p. x p) (\q p. q p)
λp p1.p(λp.p(λx y.x))
```

Note in the last line, there’s no shadowing in the user-input — a name automatically generated during normalisation ends up shadowing an environment variable, which then gets substituted in for it erroneously.

Many thanks by the way for your nice website — a useful resource!  This bug was noticed by Jonathan Osser.